### PR TITLE
Remove outdated warning about money moves not showing in YNAB

### DIFF
--- a/extension/src/components/extension/transaction/MoveMoney.tsx
+++ b/extension/src/components/extension/transaction/MoveMoney.tsx
@@ -18,10 +18,6 @@ export default function MoveMoneyWrapper() {
       <div className="heading-big">
         <div role="heading">Move money</div>
       </div>
-      <div className="mt-lg mb-lg">
-        ⚠️ Money moves made here will not show up in the &ldquo;Recent Moves&rdquo; section
-        in YNAB.
-      </div>
       {!budgetMainData || !selectedBudgetData || !popupState ? (
         <div>Loading...</div>
       ) : (


### PR DESCRIPTION
## Summary

Removed the outdated warning message in the Move Money component that stated money moves would not show up in the "Recent Moves" section in YNAB.

## Changes

- Removed the warning div from `MoveMoneyWrapper` in `extension/src/components/extension/transaction/MoveMoney.tsx` that said:
  > ⚠️ Money moves made here will not show up in the "Recent Moves" section in YNAB.

- The second warning about Credit Card Payment categories is kept since that's still relevant.

## Reason

YNAB has updated their API so money moves made through the API now appear in the "Recent Moves" section in the official app, making this warning inaccurate.