### PR TITLE
perf(ext): extend minimum token freshness

### DIFF
--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -15,7 +15,7 @@ import { AuthManager, popupStateStorage, txStore } from "~lib/state";
 import { searchWithinString, waitForInternetConnection } from "~lib/utils";
 
 export default defineBackground(() => {
-  // Handle token fetch requests from popup — runs here so the HTTP request survives popup close
+  // Handle token fetch requests from popup
   onMessage("fetchToken", ({ data: { authToken } }) => AuthManager.fetchToken(authToken));
 
   // Setup periodic background refresh

--- a/extension/src/lib/state/auth.ts
+++ b/extension/src/lib/state/auth.ts
@@ -30,8 +30,8 @@ interface AccessToken {
 
 /** Auth utilities */
 export class AuthManager {
-  /** Access token should be valid for at least 5 minutes, so we allow 4 minutes of staleness */
-  private static readonly TOKEN_STALE_TIME = ONE_MINUTE_IN_MILLIS * 4;
+  /** Access token should be valid for at least 20 minutes, so we allow 19 minutes of staleness */
+  private static readonly TOKEN_STALE_TIME = ONE_MINUTE_IN_MILLIS * 19;
 
   private static fetchTokenInFlight: ReturnType<typeof AuthManager.doFetchToken> | null =
     null;
@@ -43,10 +43,15 @@ export class AuthManager {
 
   /**
    * Fetch the unencrypted access token from the server, and save it in memory. Will
-   * clear the tokens from storage if an unauthorized error is received from the server.
-   * Deduplicates concurrent calls so only one HTTP request is in-flight at a time.
+   * return the cached token if it's still fresh. Will clear tokens from storage if an
+   * unauthorized error is received from the server. Deduplicates concurrent calls so
+   * only one HTTP request is in-flight at a time.
    */
-  static fetchToken(authToken: string) {
+  static async fetchToken(authToken: string) {
+    const currentToken = await accessTokenStorage.getValue();
+    if (currentToken && !this.isAccessTokenStale(currentToken)) {
+      return { success: true, accessToken: currentToken.value } as const;
+    }
     if (!this.fetchTokenInFlight) {
       this.fetchTokenInFlight = this.doFetchToken(authToken).finally(() => {
         this.fetchTokenInFlight = null;

--- a/web/server/routes/token/index.ts
+++ b/web/server/routes/token/index.ts
@@ -4,8 +4,8 @@ import { convertToken } from "../../lib.ts";
 
 /** Token API routes for the browser extension */
 export default async function tokenRoutes(app: FastifyInstance) {
-  /** Grace period for soon-expiring token (5 minutes) */
-  const EXPIRE_GRACE_MILLIS = 5 * 60 * 1000;
+  /** Minimum time the access token should be fresh (20 minutes) */
+  const TOKEN_FRESH_MILLIS = 20 * 60 * 1000;
 
   app.route({
     method: "POST",
@@ -14,8 +14,8 @@ export default async function tokenRoutes(app: FastifyInstance) {
     handler: async (req, reply) => {
       if (!req.token) throw new Error("Expected token on request");
 
-      // If expired, refresh the token and return the updated access token along with the encrypted auth token.
-      if (req.token.expires < Date.now() + EXPIRE_GRACE_MILLIS) {
+      // If not fresh, refresh the token and return the updated access token along with the encrypted auth token.
+      if (req.token.expires < Date.now() + TOKEN_FRESH_MILLIS) {
         try {
           req.log.info("Refreshing token");
           const { token } = await app.oauth.getNewAccessTokenUsingRefreshToken(

--- a/web/test/token.test.ts
+++ b/web/test/token.test.ts
@@ -48,7 +48,7 @@ describe("API: /token routes", () => {
     const currentAuthToken = app.crypto.encryptTokenData({
       accessToken: "current-access",
       refreshToken: "current-refresh",
-      expires: Date.now() + 10 * 60 * 1000, // active for 10 minutes
+      expires: Date.now() + 30 * 60 * 1000, // active for 30 minutes
     });
 
     const response = await app.inject({


### PR DESCRIPTION
- Extends the minimum token freshness to 20 minutes to reduce `/api/token` API calls from the extension
- Centralizes the token stale/fresh check in the extension, so staleness is always checked before calling `/api/token`